### PR TITLE
Add REPL running script to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,21 +184,8 @@ tests/%.prove: tests/%
 tests/%.klab-prove: tests/%
 	$(TEST) klab-prove --backend $(TEST_SYMBOLIC_BACKEND) $< --format-failures --def-module $(KPROVE_MODULE)
 
-# For some reason, kprove needs to run inside the actual Haskell definition directory.
-# So we need to `cd` in and do `abspath` to get the correct names.
-tests/%.repl-script: tests/%
-	cd $(haskell_dir) && $(abspath $(k_bin)/kprove)                                                               \
-  -d . -m $(KPROVE_MODULE) --debug --dry-run                                                                    \
-  --haskell-backend-command '$(abspath $(repl_bin_dir))/kore-repl --repl-script $(abspath $(haskell_backend_dir))/dist/kast.kscript'  \
-  $(abspath $<)                    \
-  > $(abspath $@)
-
-# TODO: Exiting the REPL causes an abnormal exit.
-# So if we call this rule directly, the repl-script will get rebuilt every time.
-# One can save time by first calling %.repl-script and then %.run-repl, but ideally saving the script would be automatic.
-tests/%.run-repl: tests/%.repl-script
-	cd $(haskell_dir) && sh $(abspath $<)
-
+tests/%.prove-repl: tests/%
+	$(TEST) prove --backend $(TEST_SYMBOLIC_BACKEND) --debug $< --format-failures --def-module $(KPROVE_MODULE)
 
 ### Execution Tests
 

--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,7 @@ TEST_CONCRETE_BACKEND:=llvm
 TEST_SYMBOLIC_BACKEND:=haskell
 TEST:=./kewasm
 KPROVE_MODULE:=KEWASM-LEMMAS
+KPROVE_OPTIONS:=
 CHECK:=git --no-pager diff --no-index --ignore-all-space
 
 tests/%/make.timestamp:
@@ -175,13 +176,10 @@ tests/%.parse: tests/%
 	rm -rf $@-out
 
 tests/%.prove: tests/%
-	$(TEST) prove --backend $(TEST_SYMBOLIC_BACKEND) $< --format-failures --def-module $(KPROVE_MODULE)
+	$(TEST) prove --backend $(TEST_SYMBOLIC_BACKEND) $< --format-failures --def-module $(KPROVE_MODULE) $(KPROVE_OPTIONS)
 
 tests/%.klab-prove: tests/%
-	$(TEST) klab-prove --backend $(TEST_SYMBOLIC_BACKEND) $< --format-failures --def-module $(KPROVE_MODULE)
-
-tests/%.prove-repl: tests/%
-	$(TEST) prove --backend $(TEST_SYMBOLIC_BACKEND) --debug $< --format-failures --def-module $(KPROVE_MODULE)
+	$(TEST) klab-prove --backend $(TEST_SYMBOLIC_BACKEND) $< --format-failures --def-module $(KPROVE_MODULE) $(KPROVE_OPTIONS)
 
 ### Execution Tests
 

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,6 @@ TEST:=./kewasm
 KPROVE_MODULE:=KEWASM-LEMMAS
 KPROVE_OPTS:=
 CHECK:=git --no-pager diff --no-index --ignore-all-space
-PROVE_COMMAND:=prove
 
 tests/%/make.timestamp:
 	@echo "== submodule: $@"

--- a/Makefile
+++ b/Makefile
@@ -150,8 +150,9 @@ TEST_CONCRETE_BACKEND:=llvm
 TEST_SYMBOLIC_BACKEND:=haskell
 TEST:=./kewasm
 KPROVE_MODULE:=KEWASM-LEMMAS
-KPROVE_OPTIONS:=
+KPROVE_OPTS:=
 CHECK:=git --no-pager diff --no-index --ignore-all-space
+PROVE_COMMAND:=prove
 
 tests/%/make.timestamp:
 	@echo "== submodule: $@"
@@ -176,10 +177,10 @@ tests/%.parse: tests/%
 	rm -rf $@-out
 
 tests/%.prove: tests/%
-	$(TEST) prove --backend $(TEST_SYMBOLIC_BACKEND) $< --format-failures --def-module $(KPROVE_MODULE) $(KPROVE_OPTIONS)
+	$(TEST) prove --backend $(TEST_SYMBOLIC_BACKEND) $(filter --repl, $(KPROVE_OPTS)) $< --format-failures --def-module $(KPROVE_MODULE) $(filter-out --repl, $(KPROVE_OPTS))
 
 tests/%.klab-prove: tests/%
-	$(TEST) klab-prove --backend $(TEST_SYMBOLIC_BACKEND) $< --format-failures --def-module $(KPROVE_MODULE) $(KPROVE_OPTIONS)
+	$(TEST) klab-prove --backend java                $(filter --repl, $(KPROVE_OPTS)) $< --format-failures --def-module $(KPROVE_MODULE) $(filter-out --repl, $(KPROVE_OPTS))
 
 ### Execution Tests
 

--- a/Makefile
+++ b/Makefile
@@ -151,10 +151,6 @@ TEST_SYMBOLIC_BACKEND:=java
 TEST:=./kewasm
 KPROVE_MODULE:=KEWASM-LEMMAS
 CHECK:=git --no-pager diff --no-index --ignore-all-space
-haskell_backend_dir:=$(k_submodule)/haskell-backend/src/main/native/haskell-backend
-repl_bin_dir:=$(shell cd $(haskell_backend_dir) ; stack path --local-install-root)/bin
-
-tests/proofs/wrc20-do-balance-spec.k.%: KPROVE_MODULE=VERIFICATION
 
 tests/%/make.timestamp:
 	@echo "== submodule: $@"

--- a/README.md
+++ b/README.md
@@ -21,15 +21,20 @@ make build
 Run existing proofs using `make` rules.
 
 ```sh
-make tests/proofs/example-spec.k.prove     # Runs the proof for the spec in tests/proofs/example-spec.k.prove.
-make tests/proofs/example-spec.k.run-repl  # Starts an interactive REPL for running the same proof.
+make tests/proofs/example-spec.k.prove
+make tests/proofs/example-spec.k.repl
 ```
 
-Or you can run the prover on your own specification:
+You can run the prover on your own specification, with a lemmas module of your choice.
 
 ```sh
-./kewasm prove         <path>/<to>/<spec> -m LEMMAS-MODULE  # Runs the prover on the given spec, using LEMMAS-MODULE as the top-level sematics module.
-./kewasm prove --debug <path>/<to>/<spec> -m LEMMAS-MODULE  # Starts an interactive REPL for running the same proof.
+./kewasm prove <path>/<to>/<spec> -m <LEMMAS-MODULE>  # Runs the prover on the given spec, using LEMMAS-MODULE as the top-level sematics module.
+```
+
+You can add the `--repl` flag to run the proof in an interactive REPL, where you can step through the proof and explore its branches.
+
+```sh
+./kewasm prove <path>/<to>/<spec> -m <LEMMAS-MODULE>  # Runs the prover on the given spec, using LEMMAS-MODULE as the top-level sematics module.
 ```
 
 # Structure

--- a/README.md
+++ b/README.md
@@ -5,10 +5,19 @@ K Semantics of Ewasm
 
 Prototype semantics of [Ewasm](https://github.com/ewasm/design) in the K framework.
 
-```
+```sh
 git submodule update --init --recursive
 make deps
 make build
+```
+
+# Proving
+
+Run proofs using `make` rules.
+
+```sh
+make tests/proofs/example-spec.k.prove     # Runs the proof for the spec in tests/proofs/example-spec.k.prove.
+make tests/proofs/example-spec.k.run-repl  # Starts an interactive REPL for running the same proof.
 ```
 
 # Structure

--- a/README.md
+++ b/README.md
@@ -18,11 +18,18 @@ make build
 
 # Proving
 
-Run proofs using `make` rules.
+Run existing proofs using `make` rules.
 
 ```sh
 make tests/proofs/example-spec.k.prove     # Runs the proof for the spec in tests/proofs/example-spec.k.prove.
 make tests/proofs/example-spec.k.run-repl  # Starts an interactive REPL for running the same proof.
+```
+
+Or you can run the prover on your own specification:
+
+```sh
+./kewasm prove         <path>/<to>/<spec> -m LEMMAS-MODULE  # Runs the prover on the given spec, using LEMMAS-MODULE as the top-level sematics module.
+./kewasm prove --debug <path>/<to>/<spec> -m LEMMAS-MODULE  # Starts an interactive REPL for running the same proof.
 ```
 
 # Structure

--- a/kast.kscript
+++ b/kast.kscript
@@ -1,0 +1,8 @@
+alias kclaim x   = claim x  | kast -i kore -o pretty -d .build/defn/haskell /dev/stdin
+alias kaxiom x   = axiom x  | kast -i kore -o pretty -d .build/defn/haskell /dev/stdin
+alias konfig     = config   | kast -i kore -o pretty -d .build/defn/haskell /dev/stdin
+alias konfig-n x = config x | kast -i kore -o pretty -d .build/defn/haskell /dev/stdin
+alias ktry x     = try x    | kast -i kore -o pretty -d .build/defn/haskell /dev/stdin
+alias ktryf x    = tryf x   | kast -i kore -o pretty -d .build/defn/haskell /dev/stdin
+alias krule      = rule     | kast -i kore -o pretty -d .build/defn/haskell /dev/stdin
+alias krule-n x  = rule x   | kast -i kore -o pretty -d .build/defn/haskell /dev/stdin

--- a/kewasm
+++ b/kewasm
@@ -55,10 +55,10 @@ run_kast() {
 run_prove() {
     export K_OPTS=-Xmx8G
     haskell_backend_command="$k_release_dir/bin/kore-exec"
-    if $debug; then
+    if $repl; then
         haskell_backend_command="$k_release_dir/bin/kore-repl --repl-script $ewasm_dir/kast.kscript"
     fi
-    kprove --directory "$backend_dir" "$run_file" "$@" --haskell-backend-command "$haskell_backend_command" --debug
+    kprove --directory "$backend_dir" "$run_file" "$@" --haskell-backend-command "$haskell_backend_command"
 }
 
 run_klab() {
@@ -94,7 +94,7 @@ usage() {
     echo "
     usage: $0 run        [--backend (llvm|java|haskell)]      <pgm>  <K args>*
            $0 kast       [--backend (llvm|java)]              <pgm>  <output format> <K args>*
-           $0 prove      [--backend (java|haskell)] [--debug] <spec> <K args>* -m <def_module>
+           $0 prove      [--backend (java|haskell)] [--repl]  <spec> <K args>* -m <def_module>
            $0 klab-run                                        <pgm>  <K arg>*
            $0 klab-prove                                      <spec> <K arg>* -m <def_module>
            $0 klab-view                                       [<pgm>|<spec>]
@@ -131,7 +131,7 @@ run_command="$1"; shift
 [[ ! -z ${1:-} ]] || usage_fatal "Must supply a file to work on."
 
 backend="llvm"
-debug=false
+repl=false
 [[ ! "$run_command" == 'prove' ]] || backend='haskell'
 [[ ! "$run_command" =~ klab*   ]] || backend='java'
 args=()
@@ -139,12 +139,12 @@ while [[ $# -gt 0 ]]; do
     arg="$1"
     case $arg in
         --backend)    args+=("$arg" "$2") ; backend="$2"      ; shift 2 ;;
-        --debug)      args+=("$arg")      ; debug=true        ; shift   ;;
+        --repl)       args+=("$arg")      ; repl=true         ; shift   ;;
         *)            break                                             ;;
     esac
 done
 
-! $debug || [[ "$backend" == "haskell" ]] || fatal "Debug option only available for Haskell backend."
+! $repl || [[ "$backend" == "haskell" ]] || fatal "REPL option only available for Haskell backend."
 
 backend_dir="$defn_dir/$backend"
 

--- a/kewasm
+++ b/kewasm
@@ -56,7 +56,7 @@ run_prove() {
     export K_OPTS=-Xmx8G
     haskell_backend_command="$k_release_dir/bin/kore-exec"
     if $debug; then
-        haskell_backend_command="$k_release_dir/bin/kore-repl --repl-script $haskell_backend_dir/dist/kast.kscript"
+        haskell_backend_command="$k_release_dir/bin/kore-repl --repl-script $ewasm_dir/kast.kscript"
     fi
     kprove --directory "$backend_dir" "$run_file" "$@" --haskell-backend-command "$haskell_backend_command"
 }

--- a/kewasm
+++ b/kewasm
@@ -144,7 +144,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-[[ ! $debug ]] || [[ "$backend" == "haskell" ]] || fatal "Debug option only available for Haskell backend."
+! $debug || [[ "$backend" == "haskell" ]] || fatal "Debug option only available for Haskell backend."
 
 backend_dir="$defn_dir/$backend"
 

--- a/kewasm
+++ b/kewasm
@@ -8,6 +8,7 @@ wasm_dir="${WASM_DIR:-$ewasm_dir/deps/wasm-semantics}"
 build_dir="$ewasm_dir/.build"
 defn_dir="$build_dir/defn"
 lib_dir="$build_dir/local/lib"
+haskell_backend_dir="$wasm_dir/deps/k/haskell-backend/src/main/native/haskell-backend"
 k_release_dir="${K_RELEASE:-$wasm_dir/deps/k/k-distribution/target/release/k}"
 
 export PATH="$k_release_dir/lib/native/linux:$k_release_dir/lib/native/linux64:$k_release_dir/bin/:$PATH"
@@ -53,7 +54,11 @@ run_kast() {
 
 run_prove() {
     export K_OPTS=-Xmx8G
-    kprove --directory "$backend_dir" "$run_file" "$@"
+    haskell_backend_command="$k_release_dir/bin/kore-exec"
+    if $debug; then
+        haskell_backend_command="$k_release_dir/bin/kore-repl --repl-script $haskell_backend_dir/dist/kast.kscript"
+    fi
+    kprove --directory "$backend_dir" "$run_file" "$@" --haskell-backend-command "$haskell_backend_command"
 }
 
 run_klab() {
@@ -87,12 +92,12 @@ view_klab() {
 
 usage() {
     echo "
-    usage: $0 run        [--backend (llvm|java|haskell)] <pgm>  <K args>*
-           $0 kast       [--backend (llvm|java)]         <pgm>  <output format> <K args>*
-           $0 prove      [--backend (java|haskell)]       <spec> <K args>* -m <def_module>
-           $0 klab-run                                    <pgm>  <K arg>*
-           $0 klab-prove                                  <spec> <K arg>* -m <def_module>
-           $0 klab-view                                   [<pgm>|<spec>]
+    usage: $0 run        [--backend (llvm|java|haskell)]      <pgm>  <K args>*
+           $0 kast       [--backend (llvm|java)]              <pgm>  <output format> <K args>*
+           $0 prove      [--backend (java|haskell)] [--debug] <spec> <K args>* -m <def_module>
+           $0 klab-run                                        <pgm>  <K arg>*
+           $0 klab-prove                                      <spec> <K arg>* -m <def_module>
+           $0 klab-view                                       [<pgm>|<spec>]
 
        $0 run   : Run a single WebAssembly program
        $0 kast  : Parse a single WebAssembly program and output it in supported format
@@ -126,14 +131,22 @@ run_command="$1"; shift
 [[ ! -z ${1:-} ]] || usage_fatal "Must supply a file to work on."
 
 backend="llvm"
-[[ ! "$run_command" == 'prove' ]] || backend='java'
+debug=false
+[[ ! "$run_command" == 'prove' ]] || backend='haskell'
 [[ ! "$run_command" =~ klab*   ]] || backend='java'
-if [[ $# -gt 1 ]] && [[ $1 == '--backend' ]] || [[ $1 == '--definition' ]]; then
-    backend="${2#wasm-}"
-    shift 2
-fi
+args=()
+while [[ $# -gt 0 ]]; do
+    arg="$1"
+    case $arg in
+        --backend)    args+=("$arg" "$2") ; backend="$2"      ; shift 2 ;;
+        --debug)      args+=("$arg")      ; debug=true        ; shift   ;;
+        *)            break                                             ;;
+    esac
+done
+
+[[ ! $debug ]] || [[ "$backend" == "haskell" ]] || fatal "Debug option only available for Haskell backend."
+
 backend_dir="$defn_dir/$backend"
-[[ ! "$backend" == "llvm" ]] || eval $(opam config env)
 
 # get the run file
 [[ ! -z ${1:-} ]] || usage_fatal "Must supply a file to run on."

--- a/kewasm
+++ b/kewasm
@@ -58,7 +58,7 @@ run_prove() {
     if $debug; then
         haskell_backend_command="$k_release_dir/bin/kore-repl --repl-script $ewasm_dir/kast.kscript"
     fi
-    kprove --directory "$backend_dir" "$run_file" "$@" --haskell-backend-command "$haskell_backend_command"
+    kprove --directory "$backend_dir" "$run_file" "$@" --haskell-backend-command "$haskell_backend_command" --debug
 }
 
 run_klab() {


### PR DESCRIPTION
@sskeirik Gave me some nice commands for running the REPL, including a helper file which adds some aliases for unparsing Kore. This PR adds those scripts to the Makefile for ease of use.