### PR TITLE
Fix non-determinism issue in semantics

### DIFF
--- a/ewasm.md
+++ b/ewasm.md
@@ -121,8 +121,8 @@ From the `#gatheredCall`, the parameters on the stack can be consumed and passed
     syntax MemoryVariables ::= List {MemoryVariable, ""}
  // ----------------------------------------------------
 
-    syntax Instrs ::= "#gatherParams" "(" HostCall "," MemoryVariables ")"
- // --------------------------------------------------
+    syntax Instr ::= "#gatherParams" "(" HostCall "," MemoryVariables ")"
+ // ---------------------------------------------------------------------
     rule <k> #gatherParams(HC,            .MemoryVariables) => #gatheredCall(HC)     ... </k>
     rule <k> #gatherParams(HC, (IDX, LEN) MS              ) => #gatherParams(HC, MS) ... </k>
          <paramstack> PSTACK => #getRange(DATA , IDX, LEN) : PSTACK </paramstack>


### PR DESCRIPTION
Fixes #6 

The HostCalls (which are Instr) were rewritten into `#gatherParams`. But `#gatherParams`
had the sort `Instrs`. This meant that a rule such as

`eei.hostCall => #gatherParams(...)`

would get an `.EmptyStmts` inserted on the LHS to resolve the sort. That
caused non-determinism in the semantics, because there would be no rule
for a host call with no `.EmptyStmts` after it, and there is another
rule in the semantics which removes redundantd `.EmptyStmts` after a
single statement.