### PR TITLE
Use a single instruction to store EEI result

### DIFF
--- a/ewasm.md
+++ b/ewasm.md
@@ -165,14 +165,10 @@ All byte values in Ewasm are a number of bytes divisible by 4, the same number o
 Numbers are stored little-endian in Wasm, so that's the convention that's used when converting bytes to an integer, to ensure the bytes end up as given in memory.
 
 ```k
-    syntax Instrs ::= #storeEeiResult(Int, Int, Int) [function]
-                    | #storeEeiResult(Int, Bytes)    [function, klabel(storeEeiResultsBytes)]
- // -----------------------------------------------------------------------------------------
-    rule #storeEeiResult(STARTIDX, LENGTHBYTES, VALUE)
-      => (i32.const STARTIDX) (i32.const VALUE) (i32.store8)
-         #storeEeiResult(STARTIDX +Int 1, LENGTHBYTES -Int 1, VALUE /Int 256)
-      requires LENGTHBYTES >Int 0
-    rule #storeEeiResult(_, 0, _) => .Instrs
+    syntax Instr ::= #storeEeiResult(Int, Int, Int) [function]
+                   | #storeEeiResult(Int, Bytes)    [function, klabel(storeEeiResultsBytes)]
+ // ----------------------------------------------------------------------------------------
+    rule #storeEeiResult(STARTIDX, LENGTHBYTES, VALUE) => store { LENGTHBYTES STARTIDX VALUE }
 
     rule #storeEeiResult(STARTIDX, BS:Bytes)
       => #storeEeiResult(STARTIDX, lengthBytes(BS), Bytes2Int(BS, LE, Unsigned))


### PR DESCRIPTION
Fixes #12 

Same issue as with axiom 74: an extra `.EmptyStmts` got inserted in a
rule because we were rewriting from `Instr` to `Instrs`, and `Instr` is
a subsort of `Instrs`, and the sort inferencer decides that `Instrs` is
the least common type, so it interprets the LHS of rules of the form

```
rule HS:HostCall => #storeEeiResult(...)
```

as

```
rule HS:HostCall .EmptyStmts => #storeEeiResult(...)
```